### PR TITLE
fix git build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ From Git
 git clone https://github.com/CTTV/targetGenomeBrowser
 cd targetGenomeBrowser
 npm install
-npm build-browser
+gulp build-browser
 ````
 
 From npm


### PR DESCRIPTION
## What:

update README `install from git` section
## Why:

README stated use of `npm` instead of `gulp`
